### PR TITLE
修改“单挑”错误的音调

### DIFF
--- a/pinyin_data/词组.dict.yaml
+++ b/pinyin_data/词组.dict.yaml
@@ -1,4 +1,4 @@
 扎破	zhā pò
 扎着	zā zhe
 扎起	zā qǐ
-
+单挑	dān tiǎo


### PR DESCRIPTION
单挑的“挑”，意思是挑战，应该读第三声。类似还产生的联想词语建议也审查一下，这个commit只添加了基本的“单挑”读音