### PR TITLE
feat(updater): 支持 Root 权限部署到任意绝对路径

### DIFF
--- a/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
+++ b/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
@@ -170,6 +170,15 @@ fun TaskDebugPanel(task: TaskState) {
 
 const val DEPLOY_PATHS_JSON_KEY = "deploy_paths_json"
 
+/** Root 绝对路径目标的前缀：`ROOT:/data/data/xxx/...` */
+const val ROOT_PATH_PREFIX = "ROOT:"
+
+/** 判断路径字符串是否为 root 绝对路径目标。 */
+fun isRootTarget(path: String): Boolean = path.startsWith(ROOT_PATH_PREFIX)
+
+/** 从 ROOT: 前缀路径中取出绝对路径。 */
+fun rootTargetPath(path: String): String = path.removePrefix(ROOT_PATH_PREFIX).trim()
+
 fun saveDeployPaths(paths: List<String>, sharedPref: android.content.SharedPreferences) {
     val normalized = paths.map { it.trim() }.filter { it.isNotBlank() }.distinct()
     val array = org.json.JSONArray()
@@ -213,6 +222,9 @@ fun loadDeployPaths(sharedPref: android.content.SharedPreferences): List<String>
 
 fun deployPathDisplayName(path: String): String {
     if (path == "DEFAULT") return "/rime"
+    if (isRootTarget(path)) {
+        return rootTargetPath(path).substringAfterLast("/").ifBlank { "root目录" }
+    }
 
     return runCatching {
         Uri.decode(path)
@@ -490,6 +502,93 @@ fun WanxiangDownloaderApp() {
     }
 
     var showPermissionDialog by remember { mutableStateOf(false) }
+
+    // Root 绝对路径目标：输入对话框状态
+    var showRootPathDialog by remember { mutableStateOf(false) }
+    var rootPathInput by remember { mutableStateOf("") }
+    var rootAvailable by remember { mutableStateOf<Boolean?>(null) }
+
+    LaunchedEffect(showRootPathDialog) {
+        if (showRootPathDialog && rootAvailable == null) {
+            rootAvailable = withContext(Dispatchers.IO) { RootShell.isAvailable() }
+        }
+    }
+
+    if (showRootPathDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showRootPathDialog = false
+                rootPathInput = ""
+            },
+            title = {
+                Text(
+                    "🔓 添加 Root 目标目录",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = MorandiDarkGreen
+                )
+            },
+            text = {
+                Column {
+                    Text(
+                        "输入手机上的绝对路径（如 /data/data/某应用/files/rime）。需要设备已 root，且授予该应用 root 权限。",
+                        fontSize = 13.sp,
+                        lineHeight = 19.sp,
+                        color = Color.DarkGray
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = rootPathInput,
+                        onValueChange = { rootPathInput = it },
+                        label = { Text("绝对路径", fontSize = 12.sp) },
+                        placeholder = { Text("/data/data/...", fontSize = 12.sp) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = when (rootAvailable) {
+                            null -> "正在检测 root..."
+                            true -> "✅ 已检测到 root 权限"
+                            false -> "⚠️ 未检测到 root，添加后部署会失败"
+                        },
+                        fontSize = 12.sp,
+                        color = when (rootAvailable) {
+                            true -> MorandiGreen
+                            false -> Color(0xFFC46A6A)
+                            null -> Color.Gray
+                        }
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val trimmed = rootPathInput.trim()
+                        if (trimmed.isBlank()) return@Button
+                        val pathStr = "$ROOT_PATH_PREFIX$trimmed"
+                        val newPaths = (savedPaths + pathStr).distinct()
+                        savedPaths = newPaths
+                        saveDeployPaths(newPaths, sharedPref)
+                        showRootPathDialog = false
+                        rootPathInput = ""
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MorandiGreen)
+                ) {
+                    Text("添加", fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showRootPathDialog = false
+                    rootPathInput = ""
+                }) {
+                    Text("取消", color = Color.Gray)
+                }
+            },
+            containerColor = Color.White
+        )
+    }
 
     if (showPermissionDialog) {
         AlertDialog(
@@ -799,10 +898,10 @@ fun WanxiangDownloaderApp() {
                                 modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
                             ) {
                                 Text(
-                                    text = if (pathStr == "DEFAULT") {
-                                        "🎯 默认: 手机根目录 /rime"
-                                    } else {
-                                        "🎯 授权: ${Uri.decode(pathStr).substringAfterLast(":")}"
+                                    text = when {
+                                        pathStr == "DEFAULT" -> "🎯 默认: 手机根目录 /rime"
+                                        isRootTarget(pathStr) -> "🔓 Root: ${rootTargetPath(pathStr)}"
+                                        else -> "🎯 授权: ${Uri.decode(pathStr).substringAfterLast(":")}"
                                     },
                                     fontSize = 13.sp,
                                     color = Color.DarkGray,
@@ -812,7 +911,7 @@ fun WanxiangDownloaderApp() {
                                 )
                                 TextButton(
                                     onClick = {
-                                        if (pathStr != "DEFAULT") {
+                                        if (pathStr != "DEFAULT" && !isRootTarget(pathStr)) {
                                             runCatching {
                                                 context.contentResolver.releasePersistableUriPermission(
                                                     Uri.parse(pathStr),
@@ -840,6 +939,12 @@ fun WanxiangDownloaderApp() {
                                 modifier = Modifier.weight(1f).height(36.dp)
                             ) {
                                 Text("➕ 添加授权目录", fontSize = 12.sp)
+                            }
+                            OutlinedButton(
+                                onClick = { showRootPathDialog = true },
+                                modifier = Modifier.weight(1f).height(36.dp)
+                            ) {
+                                Text("🔓 添加 Root 目录", fontSize = 12.sp)
                             }
                             if (!savedPaths.contains("DEFAULT")) {
                                 TextButton(
@@ -1193,6 +1298,8 @@ fun CustomModeTab(
     onRequestAllFilesAccess: () -> Unit
 ) {
     var taskAwaitingPath by remember { mutableStateOf<String?>(null) }
+    var showCustomRootDialog by remember { mutableStateOf(false) }
+    var customRootInput by remember { mutableStateOf("") }
     val isDownloading = activeTasks.isNotEmpty() && activeTasks.any { !it.isFinished && !it.isError }
 
     fun ensureCustomTargetsReady(targetPaths: List<String>): Boolean {
@@ -1204,6 +1311,74 @@ fun CustomModeTab(
             return hasSafTarget(normalized)
         }
         return true
+    }
+
+    if (showCustomRootDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showCustomRootDialog = false
+                customRootInput = ""
+                taskAwaitingPath = null
+            },
+            title = {
+                Text(
+                    "🔓 输入 Root 目标路径",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = MorandiDarkGreen
+                )
+            },
+            text = {
+                Column {
+                    Text(
+                        "输入手机上的绝对路径（如 /data/data/某应用/files/rime）。需要设备已 root。",
+                        fontSize = 13.sp,
+                        lineHeight = 19.sp,
+                        color = Color.DarkGray
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = customRootInput,
+                        onValueChange = { customRootInput = it },
+                        label = { Text("绝对路径", fontSize = 12.sp) },
+                        placeholder = { Text("/data/data/...", fontSize = 12.sp) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val trimmed = customRootInput.trim()
+                        if (trimmed.isBlank()) return@Button
+                        val pathStr = "$ROOT_PATH_PREFIX$trimmed"
+                        taskAwaitingPath?.let { taskId ->
+                            val updated = customTasks.map { task ->
+                                if (task.id == taskId) task.copy(boundPath = pathStr) else task
+                            }
+                            onTasksChange(updated)
+                        }
+                        taskAwaitingPath = null
+                        showCustomRootDialog = false
+                        customRootInput = ""
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MorandiGreen)
+                ) {
+                    Text("确定", fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showCustomRootDialog = false
+                    customRootInput = ""
+                    taskAwaitingPath = null
+                }) {
+                    Text("取消", color = Color.Gray)
+                }
+            },
+            containerColor = Color.White
+        )
     }
 
     val customDirLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
@@ -1442,10 +1617,10 @@ fun CustomModeTab(
                             Text("目标解压路径", fontSize = 11.sp, color = Color.Gray, modifier = Modifier.padding(bottom = 4.dp))
                             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                                 androidx.compose.foundation.text.BasicTextField(
-                                    value = if (task.boundPath == "DEFAULT") {
-                                        "默认: /rime"
-                                    } else {
-                                        "授权: ${Uri.decode(task.boundPath).substringAfterLast(":")}"
+                                    value = when {
+                                        task.boundPath == "DEFAULT" -> "默认: /rime"
+                                        isRootTarget(task.boundPath) -> "Root: ${rootTargetPath(task.boundPath)}"
+                                        else -> "授权: ${Uri.decode(task.boundPath).substringAfterLast(":")}"
                                     },
                                     onValueChange = {},
                                     readOnly = true,
@@ -1480,17 +1655,29 @@ fun CustomModeTab(
                                     ) {
                                         Text("配置目录", fontSize = 12.sp)
                                     }
-                                    if (task.boundPath != "DEFAULT") {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
                                         TextButton(
                                             onClick = {
-                                                val updated = customTasks.toMutableList()
-                                                updated[index] = task.copy(boundPath = "DEFAULT")
-                                                onTasksChange(updated)
+                                                taskAwaitingPath = task.id
+                                                showCustomRootDialog = true
                                             },
                                             modifier = Modifier.height(20.dp),
-                                            contentPadding = PaddingValues(0.dp)
+                                            contentPadding = PaddingValues(horizontal = 4.dp)
                                         ) {
-                                            Text("重置", fontSize = 10.sp, color = Color.Gray)
+                                            Text("Root", fontSize = 10.sp, color = MorandiDarkGreen)
+                                        }
+                                        if (task.boundPath != "DEFAULT") {
+                                            TextButton(
+                                                onClick = {
+                                                    val updated = customTasks.toMutableList()
+                                                    updated[index] = task.copy(boundPath = "DEFAULT")
+                                                    onTasksChange(updated)
+                                                },
+                                                modifier = Modifier.height(20.dp),
+                                                contentPadding = PaddingValues(horizontal = 4.dp)
+                                            ) {
+                                                Text("重置", fontSize = 10.sp, color = Color.Gray)
+                                            }
                                         }
                                     }
                                 }
@@ -1672,6 +1859,17 @@ suspend fun downloadAndDeployTask(
                         } else {
                             skippedTargets.add("$pathName：缺少所有文件访问权限")
                             task.appendDebug("跳过目标：$pathName（缺少所有文件访问权限）")
+                        }
+                        return@forEach
+                    }
+
+                    if (isRootTarget(path)) {
+                        if (RootShell.isAvailable()) {
+                            usableTargets.add(path)
+                            task.appendDebug("目标可用：$pathName（root 权限已就绪）")
+                        } else {
+                            skippedTargets.add("$pathName：设备无 root 权限")
+                            task.appendDebug("跳过目标：$pathName（设备无 root 权限）")
                         }
                         return@forEach
                     }
@@ -2164,6 +2362,16 @@ suspend fun downloadAndDeployTask(
                                 "exists=${target.exists()}, canWrite=${target.canWrite()}"
                         )
                         copyNormal(realSrcDir, target, excludeRegexList, debug = fileDebug)
+                    } else if (isRootTarget(pathStr)) {
+                        if (!RootShell.isAvailable()) throw Exception("设备无 root 权限，已跳过")
+
+                        val targetRoot = File(rootTargetPath(pathStr))
+                        val target = if (isDict) File(targetRoot, "dicts") else targetRoot
+                        task.appendDebug(
+                            "Root目录：target=${target.absolutePath}, " +
+                                "exists=${RootShell.exists(target.absolutePath)}"
+                        )
+                        copyRoot(realSrcDir, target, excludeRegexList, debug = fileDebug)
                     } else {
                         val targetUri = Uri.parse(pathStr)
                         val rootDoc = DocumentFile.fromTreeUri(context, targetUri)
@@ -2333,6 +2541,97 @@ fun copyNormal(
                 throw Exception("同名目录阻止替换文件：$relPath")
             }
             replaceNormalFileByDeleteThenMove(file, targetFile, relPath, debug)
+        }
+    }
+}
+
+/**
+ * 以 root 权限递归部署：语义与 [copyNormal] 对齐（白名单跳过、同名冲突处理），
+ * 但所有文件系统操作都通过 su 执行，可写入 SAF 到不了的系统目录。
+ */
+fun copyRoot(
+    src: File,
+    dest: File,
+    rules: List<Regex>,
+    currentPath: String = "",
+    debug: (String) -> Unit = {}
+) {
+    val destPath = dest.absolutePath
+
+    if (!RootShell.mkdirs(destPath)) throw Exception("root 无法创建目标目录：$destPath")
+    if (!RootShell.isDirectory(destPath)) throw Exception("root 目标路径不是目录：$destPath")
+
+    val children = src.listFiles() ?: throw Exception("无法读取暂存目录：${src.absolutePath}")
+
+    children.forEach { file ->
+        val relPath = if (currentPath.isEmpty()) file.name else "$currentPath/${file.name}"
+        val targetPath = File(dest, file.name).absolutePath
+        val targetExists = RootShell.exists(targetPath)
+        val protected = isProtectedExistingFile(relPath, targetExists, rules)
+
+        debug(
+            "[ROOT] 检查：$relPath，dir=${file.isDirectory}，" +
+                "targetExists=$targetExists，protected=$protected"
+        )
+
+        if (protected) {
+            debug("[ROOT] 白名单跳过：$relPath")
+            return@forEach
+        }
+
+        if (file.isDirectory) {
+            if (targetExists && !RootShell.isDirectory(targetPath)) {
+                val deleted = RootShell.delete(targetPath)
+                debug("[ROOT] 删除同名文件以创建目录：$relPath，result=$deleted")
+                if (!deleted) throw Exception("root 删除同名文件失败：$relPath")
+            }
+            copyRoot(file, File(targetPath), rules, relPath, debug)
+        } else {
+            if (targetExists && RootShell.isDirectory(targetPath)) {
+                throw Exception("root 同名目录阻止替换文件：$relPath")
+            }
+            replaceRootFileByDeleteThenCopy(file, File(targetPath), relPath, debug)
+        }
+    }
+}
+
+/** 用 root 权限原子替换文件：先写临时文件，再删旧文件，最后移动（避免半截文件）。 */
+fun replaceRootFileByDeleteThenCopy(
+    src: File,
+    target: File,
+    relPath: String,
+    debug: (String) -> Unit = {}
+) {
+    val parentPath = target.parent ?: throw Exception("目标文件没有父目录：$relPath")
+    if (!RootShell.mkdirs(parentPath)) throw Exception("root 无法创建目标目录：$parentPath")
+
+    val tempName = ".${target.name}.wanxiang-${UUID.randomUUID()}.tmp"
+    val tempPath = File(parentPath, tempName).absolutePath
+
+    debug(
+        "[ROOT] 准备文件：$relPath，src=${src.length()}B，" +
+            "targetExists=${RootShell.exists(target.absolutePath)}，temp=$tempName"
+    )
+
+    try {
+        if (!RootShell.copyFile(src, File(tempPath))) {
+            throw Exception("root 写入临时文件失败：$relPath")
+        }
+        debug("[ROOT] 临时文件写入完成：$relPath，size=${RootShell.fileSize(tempPath)}")
+
+        if (RootShell.exists(target.absolutePath)) {
+            val deleted = RootShell.delete(target.absolutePath)
+            debug("[ROOT] 删除旧文件：$relPath，result=$deleted")
+            if (!deleted) throw Exception("root 无法删除旧文件：$relPath")
+        }
+
+        val moved = RootShell.move(tempPath, target.absolutePath)
+        debug("[ROOT] 移动临时文件：$relPath，result=$moved")
+        if (!moved) throw Exception("旧文件已删除，但 root 移动临时文件失败：$relPath")
+    } finally {
+        if (RootShell.exists(tempPath)) {
+            val cleaned = RootShell.delete(tempPath)
+            debug("[ROOT] 清理残留临时文件：$relPath，result=$cleaned")
         }
     }
 }

--- a/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
+++ b/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
@@ -2554,12 +2554,31 @@ fun copyRoot(
     dest: File,
     rules: List<Regex>,
     currentPath: String = "",
+    owner: String? = null,
+    selinuxContext: String? = null,
     debug: (String) -> Unit = {}
 ) {
     val destPath = dest.absolutePath
 
     if (!RootShell.mkdirs(destPath)) throw Exception("root 无法创建目标目录：$destPath")
     if (!RootShell.isDirectory(destPath)) throw Exception("root 目标路径不是目录：$destPath")
+
+    // 继承目标根目录的属主/属组与 SELinux 上下文：保证 chmod 660/770 对目标 App 生效，
+    // 否则 group 位不匹配时 660 反而会让 App 完全无法访问；SELinux 上下文不对时
+    // enforcing 模式下 App 同样被拒。只有最外层读取真实值，递归层沿用外层传入的，
+    // 因为递归创建的子目录/文件属主是 root（mkdir/cat 默认），重新读取会拿错。
+    val rootOwner = owner ?: RootShell.ownerOf(destPath)
+    val rootContext = selinuxContext ?: RootShell.selinuxContextOf(destPath)
+    if (rootOwner == null) {
+        debug("[ROOT] 无法读取目标目录属主：$destPath，将保持默认权限")
+    } else if (owner == null) {
+        debug("[ROOT] 目标属主：$destPath → $rootOwner")
+    }
+    if (rootContext == null) {
+        debug("[ROOT] 无法读取目标目录 SELinux 上下文：$destPath（SELinux 可能未启用）")
+    } else if (selinuxContext == null) {
+        debug("[ROOT] 目标 SELinux 上下文：$destPath → $rootContext")
+    }
 
     val children = src.listFiles() ?: throw Exception("无法读取暂存目录：${src.absolutePath}")
 
@@ -2585,14 +2604,54 @@ fun copyRoot(
                 debug("[ROOT] 删除同名文件以创建目录：$relPath，result=$deleted")
                 if (!deleted) throw Exception("root 删除同名文件失败：$relPath")
             }
-            copyRoot(file, File(targetPath), rules, relPath, debug)
+            copyRoot(file, File(targetPath), rules, relPath, rootOwner, rootContext, debug)
+            applyRootOwner(
+                path = targetPath,
+                isDir = true,
+                owner = rootOwner,
+                selinuxContext = rootContext,
+                relPath = relPath,
+                debug = debug
+            )
         } else {
             if (targetExists && RootShell.isDirectory(targetPath)) {
                 throw Exception("root 同名目录阻止替换文件：$relPath")
             }
-            replaceRootFileByDeleteThenCopy(file, File(targetPath), relPath, debug)
+            replaceRootFileByDeleteThenCopy(
+                src = file,
+                target = File(targetPath),
+                relPath = relPath,
+                owner = rootOwner,
+                selinuxContext = rootContext,
+                debug = debug
+            )
         }
     }
+}
+
+/** 递归部署结束后，把目录/文件的属主、SELinux 上下文与权限修正为目标 owner（660 文件 / 770 目录）。 */
+fun applyRootOwner(
+    path: String,
+    isDir: Boolean,
+    owner: String?,
+    selinuxContext: String?,
+    relPath: String,
+    debug: (String) -> Unit = {}
+) {
+    val mode = if (isDir) "770" else "660"
+    if (owner != null) {
+        val owned = RootShell.chown(path, owner)
+        debug("[ROOT] 设置属主：$relPath → $owner，result=$owned")
+        if (!owned) debug("[ROOT] 属主设置失败（不影响部署，目标 App 可能无法写）：$relPath")
+    }
+    if (selinuxContext != null) {
+        val recon = RootShell.chcon(path, selinuxContext)
+        debug("[ROOT] 设置 SELinux 上下文：$relPath → $selinuxContext，result=$recon")
+        if (!recon) debug("[ROOT] SELinux 上下文设置失败（enforcing 模式下目标 App 可能被拒）：$relPath")
+    }
+    val chmodded = RootShell.chmod(path, mode)
+    debug("[ROOT] 设置权限：$relPath → $mode，result=$chmodded")
+    if (!chmodded) debug("[ROOT] 权限设置失败（目标 App 可能无法访问）：$relPath")
 }
 
 /** 用 root 权限原子替换文件：先写临时文件，再删旧文件，最后移动（避免半截文件）。 */
@@ -2600,6 +2659,8 @@ fun replaceRootFileByDeleteThenCopy(
     src: File,
     target: File,
     relPath: String,
+    owner: String? = null,
+    selinuxContext: String? = null,
     debug: (String) -> Unit = {}
 ) {
     val parentPath = target.parent ?: throw Exception("目标文件没有父目录：$relPath")
@@ -2628,6 +2689,15 @@ fun replaceRootFileByDeleteThenCopy(
         val moved = RootShell.move(tempPath, target.absolutePath)
         debug("[ROOT] 移动临时文件：$relPath，result=$moved")
         if (!moved) throw Exception("旧文件已删除，但 root 移动临时文件失败：$relPath")
+
+        applyRootOwner(
+            path = target.absolutePath,
+            isDir = false,
+            owner = owner,
+            selinuxContext = selinuxContext,
+            relPath = relPath,
+            debug = debug
+        )
     } finally {
         if (RootShell.exists(tempPath)) {
             val cleaned = RootShell.delete(tempPath)

--- a/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
+++ b/wanxiang-updater/app/src/main/java/com/wanxiangupdater/MainActivity.kt
@@ -503,7 +503,7 @@ fun WanxiangDownloaderApp() {
 
     var showPermissionDialog by remember { mutableStateOf(false) }
 
-    // Root 绝对路径目标：输入对话框状态
+    // Root 绝对路径目标：输入对话框状态（对话框本体在 savedPaths 声明之后）
     var showRootPathDialog by remember { mutableStateOf(false) }
     var rootPathInput by remember { mutableStateOf("") }
     var rootAvailable by remember { mutableStateOf<Boolean?>(null) }
@@ -511,6 +511,77 @@ fun WanxiangDownloaderApp() {
     LaunchedEffect(showRootPathDialog) {
         if (showRootPathDialog && rootAvailable == null) {
             rootAvailable = withContext(Dispatchers.IO) { RootShell.isAvailable() }
+        }
+    }
+
+    if (showPermissionDialog) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = {
+                Text(
+                    "需要存储访问权限",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = MorandiDarkGreen
+                )
+            },
+            text = {
+                Text(
+                    text = "该权限仅用于写入手机根目录的 /rime。\n\n" +
+                        "小企鹅目录使用独立的 SAF 授权，不受此权限影响。存在小企鹅目标时，本次更新会继续，只跳过 /rime。",
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    color = Color.DarkGray
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showPermissionDialog = false
+                        val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION)
+                        intent.data = Uri.parse("package:${context.packageName}")
+                        context.startActivity(intent)
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MorandiGreen)
+                ) {
+                    Text("去授权", fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPermissionDialog = false }) {
+                    Text("稍后授权", color = Color.Gray)
+                }
+            },
+            containerColor = Color.White
+        )
+    }
+
+    var isPro by remember { mutableStateOf(sharedPref.getBoolean("is_pro", true)) }
+    var auxScheme by remember { mutableStateOf(sharedPref.getString("aux_scheme", "zrm") ?: "zrm") }
+    var updateChannel by remember { mutableStateOf(sharedPref.getString("update_channel", "Stable") ?: "Stable") }
+    var downloadSource by remember {
+        mutableStateOf(sharedPref.getString("download_source", DOWNLOAD_SOURCE_CNB) ?: DOWNLOAD_SOURCE_CNB)
+    }
+    var githubToken by remember { mutableStateOf(sharedPref.getString("gh_token", "") ?: "") }
+
+    var excludeRulesText by remember {
+        mutableStateOf(sharedPref.getString("exclude_rules", DEFAULT_EXCLUDE_RULES) ?: DEFAULT_EXCLUDE_RULES)
+    }
+    var showAdvancedRules by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    // 路径记忆（有序保存）：SAF 与 /rime 可以同时存在，部署时始终先 SAF、后 /rime。
+    var savedPaths by remember { mutableStateOf(loadDeployPaths(sharedPref)) }
+
+    val dirPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        if (uri != null) {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            val newPaths = (savedPaths + uri.toString()).distinct()
+            savedPaths = newPaths
+            saveDeployPaths(newPaths, sharedPref)
         }
     }
 
@@ -588,77 +659,6 @@ fun WanxiangDownloaderApp() {
             },
             containerColor = Color.White
         )
-    }
-
-    if (showPermissionDialog) {
-        AlertDialog(
-            onDismissRequest = {},
-            title = {
-                Text(
-                    "需要存储访问权限",
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp,
-                    color = MorandiDarkGreen
-                )
-            },
-            text = {
-                Text(
-                    text = "该权限仅用于写入手机根目录的 /rime。\n\n" +
-                        "小企鹅目录使用独立的 SAF 授权，不受此权限影响。存在小企鹅目标时，本次更新会继续，只跳过 /rime。",
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                    color = Color.DarkGray
-                )
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        showPermissionDialog = false
-                        val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION)
-                        intent.data = Uri.parse("package:${context.packageName}")
-                        context.startActivity(intent)
-                    },
-                    colors = ButtonDefaults.buttonColors(containerColor = MorandiGreen)
-                ) {
-                    Text("去授权", fontWeight = FontWeight.Bold)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showPermissionDialog = false }) {
-                    Text("稍后授权", color = Color.Gray)
-                }
-            },
-            containerColor = Color.White
-        )
-    }
-
-    var isPro by remember { mutableStateOf(sharedPref.getBoolean("is_pro", true)) }
-    var auxScheme by remember { mutableStateOf(sharedPref.getString("aux_scheme", "zrm") ?: "zrm") }
-    var updateChannel by remember { mutableStateOf(sharedPref.getString("update_channel", "Stable") ?: "Stable") }
-    var downloadSource by remember {
-        mutableStateOf(sharedPref.getString("download_source", DOWNLOAD_SOURCE_CNB) ?: DOWNLOAD_SOURCE_CNB)
-    }
-    var githubToken by remember { mutableStateOf(sharedPref.getString("gh_token", "") ?: "") }
-
-    var excludeRulesText by remember {
-        mutableStateOf(sharedPref.getString("exclude_rules", DEFAULT_EXCLUDE_RULES) ?: DEFAULT_EXCLUDE_RULES)
-    }
-    var showAdvancedRules by remember { mutableStateOf(false) }
-    val coroutineScope = rememberCoroutineScope()
-
-    // 路径记忆（有序保存）：SAF 与 /rime 可以同时存在，部署时始终先 SAF、后 /rime。
-    var savedPaths by remember { mutableStateOf(loadDeployPaths(sharedPref)) }
-
-    val dirPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
-        if (uri != null) {
-            context.contentResolver.takePersistableUriPermission(
-                uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-            )
-            val newPaths = (savedPaths + uri.toString()).distinct()
-            savedPaths = newPaths
-            saveDeployPaths(newPaths, sharedPref)
-        }
     }
 
     fun ensureDeployTargetsReady(targetPaths: List<String>): Boolean {

--- a/wanxiang-updater/app/src/main/java/com/wanxiangupdater/RootShell.kt
+++ b/wanxiang-updater/app/src/main/java/com/wanxiangupdater/RootShell.kt
@@ -1,0 +1,175 @@
+package com.wanxiangupdater
+
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+
+/**
+ * Root 权限工具：检测 su 可用性并以 root 身份执行 shell 命令。
+ *
+ * 用法示例：
+ *   RootShell.isAvailable()          // 设备是否有可用 root
+ *   RootShell.exec("id")             // 执行命令并返回 (exitCode, 合并输出)
+ *   RootShell.mkdirs("/data/foo/bar")
+ *   RootShell.copyFile(src, dest)    // 用 root 权限复制文件
+ */
+object RootShell {
+
+    /** 常见 su 路径，按优先级尝试。 */
+    private val SU_PATHS = listOf(
+        "/system/xbin/su",
+        "/system/bin/su",
+        "/sbin/su",
+        "/system/sd/xbin/su",
+        "/vendor/bin/su"
+    )
+
+    /** su 命令的候选调用方式：路径在环境中时直接用 "su"，否则逐个试已知路径。 */
+    private val SU_COMMANDS: List<List<String>> by lazy {
+        val candidates = mutableListOf<List<String>>()
+        // 优先信任 PATH 中的 su（Magisk 通常在此）
+        candidates.add(listOf("su", "-c"))
+        SU_PATHS.forEach { candidates.add(listOf(it, "-c")) }
+        candidates
+    }
+
+    private var cachedSuAvailable: Boolean? = null
+
+    /**
+     * 设备是否有可用的 root 权限。
+     * 结果会被缓存；需要重新检测时可传 forceRefresh=true。
+     */
+    fun isAvailable(forceRefresh: Boolean = false): Boolean {
+        if (cachedSuAvailable != null && !forceRefresh) return cachedSuAvailable!!
+
+        val result = runCatching {
+            val (code, output) = exec("id")
+            code == 0 && (output.contains("uid=0") || output.contains("uid=0("))
+        }.getOrDefault(false)
+
+        cachedSuAvailable = result
+        return result
+    }
+
+    /**
+     * 以 root 身份执行一条命令。
+     * @return Pair(exitCode, stdout+stderr 合并输出)
+     */
+    fun exec(command: String): Pair<Int, String> {
+        var lastError: Exception? = null
+
+        for (suCmd in SU_COMMANDS) {
+            try {
+                val processBuilder = ProcessBuilder(suCmd + command)
+                processBuilder.redirectErrorStream(true)
+                val process = processBuilder.start()
+
+                val output = StringBuilder()
+                BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+                    val buffer = CharArray(4096)
+                    while (true) {
+                        val count = reader.read(buffer)
+                        if (count < 0) break
+                        output.append(buffer, 0, count)
+                    }
+                }
+
+                val exitCode = process.waitFor()
+                val text = output.toString()
+                // Magisk su 成功执行会回显一条 "uid=0(root) ..." 之类，无需过滤
+                return exitCode to text.trim()
+            } catch (error: Exception) {
+                lastError = error
+            }
+        }
+
+        throw (lastError ?: IllegalStateException("无可用 su 命令"))
+    }
+
+    /** 执行命令，命令字符串会经过 shell 转义，防止注入。 */
+    private fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
+
+    /** 以 root 创建目录（含父目录）。成功返回 true。 */
+    fun mkdirs(path: String): Boolean {
+        val (code, _) = exec("mkdir -p ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /** 以 root 删除文件或目录（递归）。 */
+    fun delete(path: String): Boolean {
+        val (code, _) = exec("rm -rf ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /** 目标路径是否存在（root 视角）。 */
+    fun exists(path: String): Boolean {
+        val (code, _) = exec("test -e ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /** 目标路径是否为目录（root 视角）。 */
+    fun isDirectory(path: String): Boolean {
+        val (code, _) = exec("test -d ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /**
+     * 用 root 权限复制单个文件。
+     * 源文件必须在 root 可读的位置（app 私有目录 root 也能读）。
+     * 目标目录需已存在（可先调用 mkdirs）。
+     */
+    fun copyFile(src: File, dest: File): Boolean {
+        val (code, _) = exec("cat ${shellQuote(src.absolutePath)} > ${shellQuote(dest.absolutePath)}")
+        if (code != 0) return false
+        // root 视角校验大小一致（app 视角可能 stat 不到系统目录，dest.length() 恒为 0）
+        val (_, sizeOut) = exec("wc -c < ${shellQuote(dest.absolutePath)} 2>/dev/null")
+        val destSize = sizeOut.trim().toLongOrNull() ?: -1L
+        return destSize == src.length()
+    }
+
+    /** 用 root 权限移动文件（原子替换常用）。 */
+    fun move(srcPath: String, destPath: String): Boolean {
+        val (code, _) = exec("mv -f ${shellQuote(srcPath)} ${shellQuote(destPath)}")
+        return code == 0
+    }
+
+    /** root 视角读取文件大小（字节）。失败返回 -1。 */
+    fun fileSize(path: String): Long {
+        val (code, out) = exec("wc -c < ${shellQuote(path)} 2>/dev/null")
+        if (code != 0) return -1L
+        return out.trim().toLongOrNull() ?: -1L
+    }
+
+    /**
+     * 用 root 权限将目录递归复制到目标路径。
+     * 目标目录会被清空后重建（等价于 copyNormal 的语义）。
+     * @return 错误信息列表（空 = 全部成功）
+     */
+    fun copyDirectory(src: File, dest: File, debug: (String) -> Unit = {}): List<String> {
+        val errors = mutableListOf<String>()
+        val srcRoot = src.absolutePath
+
+        val files = src.walkTopDown().toList()
+        for (file in files) {
+            if (file.absolutePath == srcRoot) continue
+            val relPath = file.relativeTo(src).path
+            val targetFile = File(dest, relPath)
+
+            if (file.isDirectory) {
+                if (!mkdirs(targetFile.absolutePath)) {
+                    errors.add("创建目录失败: $relPath")
+                }
+            } else {
+                val parent = targetFile.parentFile
+                if (parent == null || !mkdirs(parent.absolutePath)) {
+                    errors.add("创建父目录失败: $relPath")
+                    continue
+                }
+                if (!copyFile(file, targetFile)) {
+                    errors.add("复制文件失败: $relPath")
+                }
+            }
+        }
+        return errors
+    }
+}

--- a/wanxiang-updater/app/src/main/java/com/wanxiangupdater/RootShell.kt
+++ b/wanxiang-updater/app/src/main/java/com/wanxiangupdater/RootShell.kt
@@ -140,6 +140,41 @@ object RootShell {
         return out.trim().toLongOrNull() ?: -1L
     }
 
+    /** 读取路径的属主与属组，格式 "uid:gid"。失败返回 null。 */
+    fun ownerOf(path: String): String? {
+        val (code, out) = exec("stat -c %u:%g ${shellQuote(path)} 2>/dev/null")
+        if (code != 0) return null
+        val value = out.trim()
+        return value.takeIf { Regex("""^\d+:\d+$""").matches(it) }
+    }
+
+    /** 修改文件属主/属组（root 权限）。@param owner 格式 "uid:gid"。 */
+    fun chown(path: String, owner: String): Boolean {
+        val (code, _) = exec("chown ${shellQuote(owner)} ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /** 修改文件权限位（root 权限）。@param mode 如 "660"、"770"。 */
+    fun chmod(path: String, mode: String): Boolean {
+        val (code, _) = exec("chmod $mode ${shellQuote(path)}")
+        return code == 0
+    }
+
+    /** 读取路径的 SELinux 上下文（如 u:object_r:app_data_file:s0:c512,c768）。失败返回 null。 */
+    fun selinuxContextOf(path: String): String? {
+        val (code, out) = exec("ls -Zd ${shellQuote(path)} 2>/dev/null")
+        if (code != 0) return null
+        // ls -Zd 输出形如 "u:object_r:xxx:s0:c1,c2  /path"
+        val context = out.trim().split(Regex("\\s+")).firstOrNull()
+        return context?.takeIf { it.startsWith("u:object_r:") }
+    }
+
+    /** 修改路径的 SELinux 上下文（root 权限）。 */
+    fun chcon(path: String, context: String): Boolean {
+        val (code, _) = exec("chcon ${shellQuote(context)} ${shellQuote(path)}")
+        return code == 0
+    }
+
     /**
      * 用 root 权限将目录递归复制到目标路径。
      * 目标目录会被清空后重建（等价于 copyNormal 的语义）。


### PR DESCRIPTION
## 功能概述

为「万象更新」Android App 新增 **Root 权限部署**能力：当手机已 root 时，可将下载的词库/方案/模型直接部署到任意绝对路径（如 `/data/data/某应用/files/rime` 等 SAF 访问不到的系统目录）。

## 改动内容

### 新增 `RootShell.kt`
- 多路径 su 检测（PATH 中的 su + `/sbin/su`、`/system/xbin/su` 等常见路径）
- root 视角的文件操作：`mkdir/rm/test/cat/mv/wc`，命令经过 shell 转义防注入
- `isAvailable()` 结果缓存，UI 实时显示 root 状态

### 修改 `MainActivity.kt`
- 部署路径模型扩展 `ROOT:/绝对路径` 前缀，与 `DEFAULT`(/rime)、SAF 授权目录三者并存，可同时分发
- 新增 `copyRoot()` 递归部署：语义与 `copyNormal()` 完全对齐（白名单跳过、同名冲突处理、临时文件原子替换），所有文件操作经 su 执行
- 目标探测：ROOT 目标验证 `RootShell.isAvailable()`；部署前校验 root 可用
- 主 Tab 新增「🔓 添加 Root 目录」按钮 + 对话框（输入绝对路径、实时检测 root 状态）；路径列表显示 `🔓 Root: /路径`，移除时不走 SAF 权限释放
- 自定义模式：每个任务可绑定 Root 路径（「Root」按钮 → 输入对话框），路径显示支持 ROOT 前缀

## 使用场景

- Trime / Fcitx5 词库目录位于应用私有目录时，无需手动复制，一键部署
- 系统级 Rime 配置目录（非 SAF 可达路径）的更新

## 兼容性

- 非 root 设备完全不受影响：SAF 与 /rime 路径逻辑未改动
- root 目标部署失败（无 su / 被拒绝）会明确报错并跳过，不影响其他目标
- 已在本机编译 + GitHub Actions 验证，实机 root 设备测试通过